### PR TITLE
Fixed undefined behavior in error_message_tests

### DIFF
--- a/test/error_message_tests.cpp
+++ b/test/error_message_tests.cpp
@@ -64,7 +64,7 @@ protected:
     }
     void TearDown()
     {
-        delete all_error_code;
+        delete[] all_error_code;
     }
 };
 


### PR DESCRIPTION
Calling delete on addresses returned by new[] is undefined, see below:
http://en.cppreference.com/w/cpp/language/delete
